### PR TITLE
Játékmenet manuális tesztelés

### DIFF
--- a/manual-tests/02 - Világ inicializáció lehetséges hibái.md
+++ b/manual-tests/02 - Világ inicializáció lehetséges hibái.md
@@ -12,12 +12,12 @@ A világ inicializálás működését ellenőrzi a lehetséges hibákon kereszt
 
 | Lépés # | Leírás | Várt eredmény |
 | ------- | ------ | ------------- |
-| 1. | A középső oszlopban hozz létre egy olyan linket, aminek mindkét végén ugyanaz a mező szerepel! (Például `0 0`, majd `Add Link`) | Nem történik semmi, vagy egy felugró ablak jelzi, hogy ilyet nem szabad csinálni. A teszt sikertelen, ha az alkalmazás összeomlik, vagy valamelyik outputon megjelenik egy exception. |
-| 2. | A bal oszlopban hozz létre egy olyan instabil mezőt, aminek 0 a kapacitása! (`Unstable 0 0`, `Add Tile`) | Nem történik semmi, vagy egy felugró ablak jelzi, hogy ilyet nem szabad csinálni. A teszt sikertelen, ha sikerül ilyen mezőt létrehozni (hiszen 0 kapacitású instabil mezőnek nincs értelme, az egy lyukas mezővel érne fel). |
-| 3. | Próbálj meg a bal oszlopban helytelen értékeket beírni a szám mezőkbe: Negatív számok, szöveg, tizedespont / vessző, speciális karakterek! | Nem sikerül egyiket sem beírni, a mezőkben mindig érvényes nemnegatív egész szám látszódik. |
-| 4. | A jobb oszlopban próbálj meg ugyanahhoz a mezőhöz több ugyanolyan, vagy különböző itemet is hozzáadni! (Például `0 Gun`, `0 Gun`, `0 Cartridge`, `0 Beacon`, mindegyik után egy `Add Item`-et nyomva.) | Csak egyet sikerül létrehozni a mezőn, többet nem enged az alkalmazás. A teszt sikertelen, ha ugyanarra a mezőre több tárgyat is le lehet tenni. |
-| 5. | Hozd létre az eddigi pályát! (`OK` gomb), majd nyisd meg ismét a világ inicializáló menüt, és kattints bármiféle egyéb beállítás nélkül az `OK` gombra! | A korábban létrehozott mezők eltűnnek a játéktérről, az összes panel üres. |
-
+| 1. | Próbálj meg létrehozni tárgyat úgy, hogy még nincsenek mezők létrehozva (kattints az `Add item` gombra mielőtt bármit csinálnál) | Nem történik semmi, vagy egy felugró ablak jelzi, hogy ilyet nem szabad csinálni. A teszt sikertelen, ha az alkalmazás összeomlik, vagy valamelyik outputon megjelenik egy exception. |
+| 2. | A középső oszlopban hozz létre egy olyan linket, aminek mindkét végén ugyanaz a mező szerepel! (Például `0 0`, majd `Add Link`) | Nem történik semmi, vagy egy felugró ablak jelzi, hogy ilyet nem szabad csinálni. A teszt sikertelen, ha az alkalmazás összeomlik, vagy valamelyik outputon megjelenik egy exception. |
+| 3. | A bal oszlopban hozz létre egy olyan instabil mezőt, aminek 0 a kapacitása! (`Unstable 0 0`, `Add Tile`) | Nem történik semmi, vagy egy felugró ablak jelzi, hogy ilyet nem szabad csinálni. A teszt sikertelen, ha sikerül ilyen mezőt létrehozni (hiszen 0 kapacitású instabil mezőnek nincs értelme, az egy lyukas mezővel érne fel). |
+| 4. | Próbálj meg a bal oszlopban helytelen értékeket beírni a szám mezőkbe: Negatív számok, szöveg, tizedespont / vessző, speciális karakterek! | Nem sikerül egyiket sem beírni, a mezőkben mindig érvényes nemnegatív egész szám látszódik. |
+| 5. | A jobb oszlopban próbálj meg ugyanahhoz a mezőhöz több ugyanolyan, vagy különböző itemet is hozzáadni! (Például `0 Gun`, `0 Gun`, `0 Cartridge`, `0 Beacon`, mindegyik után egy `Add Item`-et nyomva.) | Csak egyet sikerül létrehozni a mezőn, többet nem enged az alkalmazás. A teszt sikertelen, ha ugyanarra a mezőre több tárgyat is le lehet tenni. |
+| 6. | Hozd létre az eddigi pályát! (`OK` gomb), majd nyisd meg ismét a világ inicializáló menüt, és kattints bármiféle egyéb beállítás nélkül az `OK` gombra! | A korábban létrehozott mezők eltűnnek a játéktérről, az összes panel üres. |
 
 ## Megjegyzések
 

--- a/manual-tests/07 - Pálya mentése és betöltése 2.md
+++ b/manual-tests/07 - Pálya mentése és betöltése 2.md
@@ -1,0 +1,60 @@
+# 07 - Pálya mentése és betöltése 2
+
+A pálya mentés, illetve a pálya betöltés funkciók működését ellenőrzi egy nagyobb pályán.
+
+## Bemeneti adatok
+*Bizonyos lépéseknél szükség van nagyobb mennyiségű bemeneti adatra.
+Ezek az átláthatóság kedvéért ebben a részben vannak felsorolva.*
+
+1. Paraméterek a világ inicializáló menü első oszlopához:
+    * `Stable 1 0`
+    * `Stable 1 0`
+    * `Stable 1 0`
+    * `Stable 1 0`
+    * `Stable 1 0`
+    * `Stable 1 0`
+    * `Stable 1 0` 
+    (7 darab Stable tile)
+    * `Unstable 0 3`
+    * `Unstable 1 3`
+    * `Hole 0 0`
+2. Paraméterek a világ inicializáló menü második oszlopához:
+    * `0 1`
+    * `1 2`
+    * `2 3`
+    * `3 4`
+    * `4 5`
+    * `5 6`
+    * `6 7`
+    * `7 8`
+    * `8 9`
+    * `0 9`
+3. Paraméterek a világ inicializáló menü harmadik oszlopához:
+    * `0 Beacon `
+    * `1 Cartridge `
+    * `2 Gun `
+    * `3 Rope `
+    * `4 Divingsuit `
+    * `5 Shovel `
+    * `6 Brokenshovel `
+    * `7 Tent`
+    * `8 Food`
+4. Paraméterek az élőlény inicializáló menühöz:
+    * `0 Eskimo`
+    * `0 Researcher`
+
+## Előkészítés
+
+1. Indítsd el az alkalmazás grafikus felületét!
+2. Végezd el a világ inicializálását az `Initialization -> Init World` menüpont alatt a fenti bemeneti adatokkal! Mindegyik adat után meg kell nyomni a releváns oszlopban lévő `Add` gombot, majd legvégül az `OK` gombot.
+3. Végezd el az élőlények inicializálását az `Initialization -> Init Creatures` menüpont alatt a fenti bemeneti adatokkal! Mindegyik adat után meg kell nyomni az `Add Creature` gombot, majd legvégül az `OK` gombot.
+4. Ezek után a játéktéren látnod kell három összekötött mezőt, rajtuk 2, 1, illetve 0 élőlénnyel.
+
+## Lépések
+
+| Lépés # | Leírás | Várt eredmény |
+| ------- | ------ | ------------- |
+| 1. | Kattints a `File -> Save` menüpontra. Válassz egy tetszőleges mappát és fájlnevet (például `world.txt`), majd kattints a `Save` gombra! | A grafikus felületen lent középen egy visszaigazoló üzenet kell megjelenjen, ami szerint `World saved successfully!`. Ha ez nem jelenik meg, a teszt sikertelen - ez nem egy életbevágóan fontos funkció, de a felhasználó örül minden visszajelzésnek. |
+| 2. | Győződj meg arról, hogy ott, ahol elmentetted a fájlt, tényleg létrejött egy vagy több új fájl! Nyisd meg őket! | A fájl(ok) léteznek, nem üresek, és a tartalmuk érzésre megegyezik azzal, amik az előkészítés fázisban létrejöttek. |
+| 3. | Indítsd el az alkalmazást egy újabb példányban! Ebben az új példányban kattints a `File -> Load` menüpontra. Keresd ki az előbb elmentett fájlt! (Pontosan azt! - Előfordulhatnak hasonló nevű fájlok is.) Válaszd ki, majd kattints az `Open`-re. | A grafikus felület konzolján egy visszaigazoló üzenetet kell látnod, miszerint `World loaded successfully!`, illetve a játéktéren látnod kell a korábban elmentett mezőket és élőlényeket. |
+| 4. | Hasonlítsd össze az alkalmazás két példányának játékterét és `Creatures` paneljét! | A két példányban ugyanazokat a mezőket, élőlényeket, és adatokat kell látnod, ugyanabban az elrendezésben. |

--- a/manual-tests/07 - Pálya mentése és betöltése 2.md
+++ b/manual-tests/07 - Pálya mentése és betöltése 2.md
@@ -48,7 +48,7 @@ Ezek az átláthatóság kedvéért ebben a részben vannak felsorolva.*
 1. Indítsd el az alkalmazás grafikus felületét!
 2. Végezd el a világ inicializálását az `Initialization -> Init World` menüpont alatt a fenti bemeneti adatokkal! Mindegyik adat után meg kell nyomni a releváns oszlopban lévő `Add` gombot, majd legvégül az `OK` gombot.
 3. Végezd el az élőlények inicializálását az `Initialization -> Init Creatures` menüpont alatt a fenti bemeneti adatokkal! Mindegyik adat után meg kell nyomni az `Add Creature` gombot, majd legvégül az `OK` gombot.
-4. Ezek után a játéktéren látnod kell három összekötött mezőt, rajtuk 2, 1, illetve 0 élőlénnyel.
+4. Ezek után a játéktéren látnod kell tíz összekötött mezőt, rajtuk két élőlénnyel.
 
 ## Lépések
 

--- a/manual-tests/08 - Játék elindítása kézzel elkészített pályából.md
+++ b/manual-tests/08 - Játék elindítása kézzel elkészített pályából.md
@@ -1,0 +1,28 @@
+# 08 - Játék elindítása kézzel elkészített pályából
+
+Annak a tesztelése hogy sikeresen el lehet-e indítani a játékot.
+
+## Bemeneti adatok
+*Bizonyos lépéseknél szükség van nagyobb mennyiségű bemeneti adatra.
+Ezek az átláthatóság kedvéért ebben a részben vannak felsorolva.*
+
+1. Paraméterek a világ inicializáló menü első oszlopához:
+    * `Stable 0 0`
+    * `Unstable 0 3`
+    * `Hole 0 0`
+2. Paraméterek a világ inicializáló menü második oszlopához:
+    * `0 1`
+    * `0 2`
+    * `1 2`
+
+## Előkészítés
+
+1. Indítsd el az alkalmazás grafikus felületét!
+2. Végezd el a [01 - Világ inicializáció sanity check](01%20-%20Világ%20inicializáció%20sanity%20check.md) tesztet a pálya létrehozásához!
+3. Végezd el a [02 - Előlény inicializáció sanity check](03%20-%20Élőlény%20inicializáció%20sanity%20check.md) tesztet a lények létrehozásához!
+
+## Lépések
+
+| Lépés # | Leírás | Várt eredmény |
+| ------- | ------ | ------------- |
+| 1. | Kattints a játék jobb oldalán a `Start automated game` gombra | A játék jobb oldalán megjelenik egy lista a lehetséges cselekvésekkel: `Move`, `Dig`, `Use manual tool`, `Use character ability`, `Pick up item from current tile`, `Build flare`, `Finish round`, `Stop game`. Alul megjelenik a `Game Started` és a `Player 0, yout're up!` üzenet  |

--- a/manual-tests/09 - Játék elindítása betöltött pályából.md
+++ b/manual-tests/09 - Játék elindítása betöltött pályából.md
@@ -1,0 +1,20 @@
+# 09 - Játék elindítása betöltött pályából
+
+Annak a tesztelése hogy sikeresen el lehet-e indítani a játékot. Ezúttal úgy hogy a pályát nem kézzel készítjük el, hanem betöltjük egy mentésből.
+
+## Bemeneti adatok
+*Bizonyos lépéseknél szükség van nagyobb mennyiségű bemeneti adatra.
+Ezek az átláthatóság kedvéért ebben a részben vannak felsorolva.*
+
+1. [smallWorld.txt](resources/smallWorld.txt), mint szöveges fájl.
+
+## Előkészítés
+
+1. Indítsd el az alkalmazás grafikus felületét!
+2. Töltsd be a pályát: `File -> Load`, keresd meg és válaszd ki a resources/savedWorld.txt-t, `Open`.
+
+## Lépések
+
+| Lépés # | Leírás | Várt eredmény |
+| ------- | ------ | ------------- |
+| 1. | Kattints a játék jobb oldalán a `Start automated game` gombra | A játék jobb oldalán megjelenik egy lista a lehetséges cselekvésekkel: `Move`, `Dig`, `Use manual tool`, `Use character ability`, `Pick up item from current tile`, `Build flare`, `Finish round`, `Stop game`. Alul megjelenik a `Game Started` és a `Player 0, yout're up!` üzenet  |

--- a/manual-tests/10 - Játék elindításának lehetséges hibái.md
+++ b/manual-tests/10 - Játék elindításának lehetséges hibái.md
@@ -1,0 +1,17 @@
+# 10 - Játék elindításának lehetséges hibái.
+
+Azt teszteli hogy lehetséges-e olyan pályát készíteni hogy a játék hibásan indul el.
+
+## Előkészítés
+
+1. Indítsd el az alkalmazás grafikus felületét!
+
+## Lépések
+
+| Lépés # | Leírás | Várt eredmény |
+| ------- | ------ | ------------- |
+| 1. | Próbáld meg úgy elindítani a játékot hogy nincs betöltve pálya. | Nem jelenik meg a `Start automated game` gomb. |
+| 2. | Próbáld meg úgy elindítani a játékot hogy megnyitod a világ inicializálót (`Initializaion -> Init World`), de nem állítasz be semmit hanem egyből `Ok`-t nyomsz. | Nem jelenik meg a `Start automated game` gomb. |
+| 3. | Próbáld meg úgy elindítani a játékot hogy inicializálod a világot valamivel (`Initializaion -> Init World`), de utána nem állítasz be élőlényeket. Próbálj ki különbözőféleképpen inicializált világokat. | Nem jelenik meg a `Start automated game` gomb. |
+| 4. | Próbáld meg úgy elindítani a játékot hogy inicializálod a világot valamivel, mint az előző lépésben, utána elindítod az élőlény inicializálót (`Initialization -> Init Creatures`) és nem állítasz be semmit hanem egyből `Ok`-t nyomsz. | Nem jelenik meg a `Start automated game` gomb. |
+| 5. | Próbáld meg úgy elindítani a játékot hogy inicializálod a világot valamivel, mint az előző lépésben, utána elindítod az élőlény inicializálót (`Initialization -> Init Creatures`) és csak jegesmedvét teszel be (`Polarbear` kiválasztása, majd `Add creature`).  | Nem jelenik meg a `Start automated game` gomb, vagy megjelenik és rákattintva elindul a játék, és lehet látni ahogy mozog a jegesmedve. |

--- a/manual-tests/11 - Új játék kezdése amikor már fut egy.md
+++ b/manual-tests/11 - Új játék kezdése amikor már fut egy.md
@@ -1,0 +1,33 @@
+# 11 - Új játék kezdése, amikor már fut egy
+
+Azt teszteli, hogyha el van már indítva egy játék akkor jól működik-e egy újabb játék indítása.
+
+## Bemeneti adatok
+*Bizonyos lépéseknél szükség van nagyobb mennyiségű bemeneti adatra.
+Ezek az átláthatóság kedvéért ebben a részben vannak felsorolva.*
+
+1. [smallWorld.txt](resources/smallWorld.txt), mint szöveges fájl.
+
+2. Paraméterek a világ inicializáló menü első oszlopához:
+    * `Stable 0 0`
+    * `Unstable 0 3`
+    * `Hole 0 0`
+3. Paraméterek a világ inicializáló menü második oszlopához:
+    * `0 1`
+    * `0 2`
+    * `1 2`
+
+## Előkészítés
+
+1. Indítsd el az alkalmazás grafikus felületét!
+2. Töltsd be a pályát: `File -> Load`, keresd meg és válaszd ki a resources/smallWorld.txt-t, `Open`.
+3. Indítsd el a játékot: `Start automated game`.
+
+## Lépések
+
+| Lépés # | Leírás | Várt eredmény |
+| ------- | ------ | ------------- |
+| 1. | A `File -> Load`-al töltsd be újra a resources/smallWorld.txt-t. | Eltűnnek jobboldalról a cselekvés gombok, már nem fut a játék és a pálya a kezdeti helyzetbe kerül. |
+| 2. | Indítsd el a játékot: `Start automated game`. | Elindul a játék, megjelennek a cselekvés gombok. |
+| 3. | Kézzel készítsd el a pályát `Initialization -> Init World`, `Initialization -> Init Creatures`-el és a fent megadott adatokkal. | Eltűnnek jobboldalról a cselekvés gombok, már nem fut a játék és a pálya a kezdeti helyzetbe kerül. |
+| 4. | Indítsd el a játékot: `Start automated game`. | Elindul a játék, megjelennek a cselekvés gombok. |

--- a/manual-tests/12 - A játék mező GUI hibáinak felfedezése.md
+++ b/manual-tests/12 - A játék mező GUI hibáinak felfedezése.md
@@ -1,0 +1,30 @@
+# 12 - A játék mezők megjelenítése GUI hibáinak felfedezése
+
+Az a célja ennek a tesztnek, hogy a tesztelő megpróbálja valahogyan elrontani a mezők megjelenítését.
+
+## Bemeneti adatok
+*Bizonyos lépéseknél szükség van nagyobb mennyiségű bemeneti adatra.
+Ezek az átláthatóság kedvéért ebben a részben vannak felsorolva.*
+
+1. [smallWorld.txt](resources/smallWorld.txt), mint szöveges fájl.
+
+## Előkészítés
+
+1. Indítsd el az alkalmazás grafikus felületét!
+2. Töltsd be a pályát: `File -> Load`, keresd meg és válaszd ki a resources/smallWorld.txt-t, `Open`.
+
+## Lépések
+
+| Lépés # | Leírás | Várt eredmény |
+| ------- | ------ | ------------- |
+| 1. | Próbáld ki hogy el tudod-e mozdítani a mezőket a bal egér gomb lenyomásával a mező fölött és húzással. | Elmozdulnak a húzott mező. |
+| 2. | Próbáld meg úgy elmozdítani a mezőket hogy nem kattintasz rájuk csak melléjük, vagy valahova máshova az interface-en. | Csak akkor mozdulnak el a mezők ha rajtuk nyomod le az egérgombot. |
+| 3. | Próbálj több részén lenyomni a gombot a mezőknek, olyat részt keresve, ahol nem működik az elmozdítás. | Mindig elmozdulnak a mezők bárhol van rajtuk az egér. |
+| 4. | Próbáld meg úgy elmozdítani a mezőket hogy az összekötő vonalak nem elvártan viselkednek. | Mindig össze kell legyenek kötve egy látható fekete vonallal a szomszédos mezők. |
+| 5. | Próbáld kimozdítani a mezőket a játéktérből. Minden irányba próbáld meg kihúzni őket (fel, le, balra, jobbra) | Ki lehet mozdítani a mezőket a játéktérből, és olyankor megjelennek oldalt Scrollbar-ok, melyekkel a kimozdított mezőkhöz lehet mozdítani a játékteret. |
+| 6. | Próbáld átméretezni a játék ablak méretét. | Át lehet méretezni a játékablakot és különböző méretekben is játszható marad a játék. |
+
+
+## Megjegyzések
+
+* Ezeknél a teszteknél egy kicsi próbálgatás/felfedezés is elvárt a tesztelőtől.

--- a/manual-tests/13 - Játékmenet teszt.md
+++ b/manual-tests/13 - Játékmenet teszt.md
@@ -1,0 +1,46 @@
+# 13 - Játékmenet teszt
+
+Teszteli a játékmenet különböző aspektusainak a grafikus megjelenítését.
+
+## Bemeneti adatok
+*Bizonyos lépéseknél szükség van nagyobb mennyiségű bemeneti adatra.
+Ezek az átláthatóság kedvéért ebben a részben vannak felsorolva.*
+
+1. [bigWorld.txt](resources/bigWorld.txt), mint szöveges fájl.
+
+## Előkészítés
+
+1. Indítsd el az alkalmazás grafikus felületét!
+2. Töltsd be a pályát: `File -> Load`, keresd meg és válaszd ki a resources/bigWorld.txt-t, `Open`.
+3. Indítsd el a játékot: `Start automated game`.
+
+## Lépések
+
+| Lépés # | Leírás | Várt eredmény |
+| ------- | ------ | ------------- |
+| 1. | Kattints a `Move` gombra és válaszd ki az `1`-es mezőt. | A `0`-ás számú téglalap áthelyeződik az `1`-es számú mezőre. Az `Eskimo 0` játékos alatti `WU:` mellett levő érték 1-el csökkent. |
+| 2. | Kattints a `Dig` gombra. | Az `1`-es mezőn eltűnik a középső négyzetből a szám és helyette megjelenik egy `I` betű. Az `Eskimo 0` játékos alatti `WU:` mellett levő érték 1-el csökkent.|
+| 3. | Kattints a `Pick up item from current tile` gombra. | Az `1`-es mezőn eltűnik a középső négyzetből az `I` betű és baloldalt a `Flareparts` felirat alatt megjelenik a `cartridge`. Az `Eskimo 0` játékos alatti `WU:` mellett levő érték 1-el csökkent.|
+| 4. | Kattints a `Use character ability` gombra. | Az `1`-es mezőn a jobb oldali négyzetben egy `I` betű jelenik meg. Az `Eskimo 0` játékos alatti `WU:` mellett levő érték 1-el csökkent.|
+| 5. | Próbáld ki az összes lehetőséget jobb oldalról, kivéve a `Finish round` és `Stop game`-et. | Egyik cselekvés se kéne sikerüljön, mert nincs elég work unit-ja a játékosnak. |
+| 6. | Kattints a `Finish round`-ra. | Alul megjelenik hogy `Player 1, you're up!` |
+| 7. | Most az `1`-es játékost irányítod. Menj el vele egymás után több move-al a `4`-es mezőre, az `1`-es mező fele indulva. | Az `1`-es számú téglalap mindig átlép a következő mezőre. |
+| 8. | Nyomd meg kétszer a `Finish round`-ot. | Átvált a `0`-ás játékosra, majd vissza az `1`-esre. |
+| 9. | Menj át az `1`-es játékossal a 6-os mezőre. | Ahogy eddig is, a téglalap helyet vált. |
+| 10. | Nyomd meg a `Use character ability` gombot. | A `6`-os mezőn eltűnik a `??` és helyébe `s(-1)` lesz. |
+| 11. | Menj át a `7`-es mezőre az `1`-es játékossal. | Az `1`-es játékos átkerül a `7`-es mezőre. |
+| 12. | Nyomd meg kétszer a `Finish round`-ot. | Átvált a `0`-ás játékosra, majd vissza az `1`-esre. |
+| 13. | Nyomd meg a `Use character ability` gombot. | A `7`-es mezőn eltűnik a `??` és helyébe `u(3)` lesz. |
+| 14. | Áss addig a `Dig` gombbal, amíg elfogy a hó. | A `7`-es mezőn először csökken a középső négyzetben az érték, majd eltűnik és egy `I` betű lesz helyette. |
+| 15. | Nyomd meg a `Pick up item from current tile` gombot. | Az `1`-es mezőn eltűnik a középső négyzetből az `I` betű és baloldalt a `Researcher 1` alatt megjelenik a `tentequipment` |
+| 16. | Nyomd meg kétszer a `Finish round`-ot. | Átvált a `0`-ás játékosra, majd vissza az `1`-esre. |
+| 17. | Nyomd meg a `Use manual tool` gombot, majd az `Ok`-t. | A `7`-es mezőn a jobb oldali négyzetben egy `T` betű jelenik meg. |
+
+
+## Megjegyzések
+
+* Mivel a hóviharok véletlenszerűen érkeznek ezért más lehet minden teszteléskor egy kicsit a pálya. Egyes mezőkön több hó lehet. Ilyenkor a tesztekben ha havat kell ásni, akkor addig áss, amíg elfogy az összes. Ez elronthatja a következő lépéseket is, mert kevesebb WU-ja lesz a játékosnak, ilyenkor a `Finish round` kétszeri megnyomásával visszakerülünk az eredeti játékoshoz, de most már tele WU-val.
+
+* A WU fogyásának a vizsgálását csak az elejére írtam le, de ez később is kell működjön.
+
+* Az is megtörténhet hogy a teszt során a hóviharok megölnek egy játékost és vége lesz a játéknak. Ilyenkor kezdd elölről a tesztet, egy idő után túl fognak élni.

--- a/manual-tests/14 - Medve tesztelése.md
+++ b/manual-tests/14 - Medve tesztelése.md
@@ -1,0 +1,25 @@
+# 14 - Medve tesztelése
+
+Teszteli a medvét.
+
+## Bemeneti adatok
+*Bizonyos lépéseknél szükség van nagyobb mennyiségű bemeneti adatra.
+Ezek az átláthatóság kedvéért ebben a részben vannak felsorolva.*
+
+1. [bearWorld.txt](resources/bearWorld.txt), mint szöveges fájl.
+
+## Előkészítés
+
+1. Indítsd el az alkalmazás grafikus felületét!
+2. Töltsd be a pályát: `File -> Load`, keresd meg és válaszd ki a resources/bigWorld.txt-t, `Open`.
+3. Indítsd el a játékot: `Start automated game`.
+
+## Lépések
+
+| Lépés # | Leírás | Várt eredmény |
+| ------- | ------ | ------------- |
+| 1. | Nyomogasd a `Finish round` gombot. | A medve (kék téglalap), mozog jobbra balra. Ha eleget nyomod a `Finish round`-ot, egy idő után elkapja a játékost, és vége a játéknak. |
+
+## Megjegyzések
+
+* Lehetséges hogy a játékos hamarabb hal meg hóvihar miatt, minthogy találkozzon a medvével.

--- a/manual-tests/resources/bearWorld.txt
+++ b/manual-tests/resources/bearWorld.txt
@@ -1,0 +1,28 @@
+worlddata
+    step 10
+    activeplayer none
+    flareparts 0
+tiles 8
+    0 stable 0 n none none 
+    1 stable 0 n none none 
+    2 stable 0 n none none 
+    3 stable 0 n none none 
+    4 stable 0 n none none 
+    5 stable 0 n none none 
+    6 stable 0 n none none 
+    7 stable 0 n none none 
+tilelinks 8
+    0 1
+    0 7
+    1 2
+    2 3
+    3 4
+    4 5
+    5 6
+    6 7
+creatures 2
+    0 eskimo 0 5 4
+        rope none
+        suit none
+        usableitems 0
+    1 polarbear 4

--- a/manual-tests/resources/bigWorld.txt
+++ b/manual-tests/resources/bigWorld.txt
@@ -1,0 +1,35 @@
+worlddata
+    step 0
+    activeplayer none
+    flareparts 0
+tiles 10
+    0 stable 1 n none beacon 
+    1 stable 1 n none cartridge 
+    2 stable 1 n none gun 
+    3 stable 1 n none basicrope 
+    4 stable 1 n none basicdivingsuit 
+    5 stable 1 n none shovel 
+    6 stable 1 n none brokenshovel 
+    7 unstable 0 n none tent 3
+    8 unstable 1 n none food 3
+    9 hole 0 n none none 
+tilelinks 10
+    0 1
+    0 9
+    1 2
+    2 3
+    3 4
+    4 5
+    5 6
+    6 7
+    7 8
+    8 9
+creatures 2
+    0 eskimo 0 5 4
+        rope none
+        suit none
+        usableitems 0
+    1 researcher 0 5 4
+        rope none
+        suit none
+        usableitems 0

--- a/manual-tests/resources/smallWorld.txt
+++ b/manual-tests/resources/smallWorld.txt
@@ -1,0 +1,22 @@
+worlddata
+    step 0
+    activeplayer none
+    flareparts 0
+tiles 3
+    0 stable 0 n none beacon 
+    1 unstable 0 n none basicrope 3
+    2 hole 0 n none none 
+tilelinks 3
+    0 1
+    0 2
+    1 2
+creatures 3
+    0 eskimo 0 5 4
+        rope none
+        suit none
+        usableitems 0
+    1 researcher 0 5 4
+        rope none
+        suit none
+        usableitems 0
+    2 polarbear 1

--- a/manual-tests/results/Eredmények - 2021.05.16.md
+++ b/manual-tests/results/Eredmények - 2021.05.16.md
@@ -1,0 +1,23 @@
+# Manuális tesztek eredményei
+
+Ebben a fájlban táblázatos formában szerepel az, hogy az egyes tesztek sikeresek voltak-e, vagy nem.
+
+* A tesztek végzője: *Kacsó Péter Gábor*
+* A tesztelés időpontja: *2021. május 16.*
+
+| Elvégzett teszteset neve | Sikeres? | Megjegyzések |
+| ------------------------ | -------- | ------------ |
+| [01 - Világ inicializáció sanity check](../01%20-%20Világ%20inicializáció%20sanity%20check.md) | Igen | |
+| [02 - Világ inicializáció lehetséges hibái](../02%20-%20Világ%20inicializáció%20lehetséges%20hibái.md) | Nem | A 2. lépésben létre lehet hozni olyan instabil mezőt, aminek 0 a kapacitása, illetve a 4. lépésben több eszközt is létre lehet hozni ugyanazon a mezőn. Ezenkívül ha megpróbálok létrehozni tárgyat, még azelőtt hogy mezőket készítettem volna, akkor bár úgy tűnik hogy nem engedi, később ha beteszünk egy másik tárgyat, akkor megjelennek -1 index-el azok a tárgyak, melyeket mező nélkül hoztunk létre. |
+| [03 - Élőlény inicializáció sanity check](../03%20-%20Élőlény%20inicializáció%20sanity%20check.md) | Igen | |
+| [04 - Élőlény inicializáció lehetséges hibái](../04%20-%20Élőlény%20inicializáció%20lehetséges%20hibái.md) | Igen | |
+| [05 - Pálya mentése és betöltése](../05%20-%20Pálya%20mentése%20és%20betöltése.md) | Igen | |
+| [06 - Pálya betöltése GUI nélküli mentésből](../06%20-%20Pálya%20betöltése%20GUI%20nélküli%20mentésből.md) | Igen | |
+| [07 - Pálya mentése és betöltése 2](../07%20-%20Pálya%20mentése%20és%20betöltése%202) | Nem | Bár úgy tűnik hogy jól elmenti, a betöltés nem sikerül, error-t ír ki: `> Error: Could not load savefile. The file either doesn't exist,or it's not a proper save file. > Cause: Invalid Tile config!` |
+| [08 - Játék elindítása kézzel elkészített pályából](../08%20-%20Játék%20elindítása%20kézzel%20elkészített%20pályából.md) | Igen | |
+| [09 - Játék elindítása betöltött pályából](../09%20-%20Játék%20elindítása%20betöltött%20pályából.md) | Igen | |
+| [10 - Játék elindításának lehetséges hibái](../10%20-%20Játék%20elindításának%20lehetséges%20hibái.md) | Nem | Engedi hogy elindítsuk a játékot csak medvével, és utána egyből kifagy a program. |
+| [11 - Új játék kezdése amikor már fut egy](../11%20-%20Új%20játék%20kezdése%20amikor%20már%20fut%20egy.md) | Nem | Ha kézzel próbáljuk elkészíteni a pályát, akkor semmi nem történik az `Ok`-ra kattintás után. Ezután egyáltalán nem megy a megmaradt játék sem, nincs hatása a gomboknak. |
+| [12 - A játék mező GUI hibáinak felfedezése](../12%20-%20A%20játék%20mező%20GUI%20hibáinak%20felfedezése.md) | Nem | Ha balra vagy felfele kihúzunk egy mezőt és elengedjük, akkor azt már sose tudjuk elérni és látni. |
+| [13 - Játékmenet teszt](../13%20-%20Játékmenet%20teszt.md) | Igen | |
+| [14 - Medve tesztelése](../14%20-%20Medve%20tesztelése.md) | Igen | |


### PR DESCRIPTION
A játékmenet grafikai megjelenítésére vonatkozó manuális tesztek, és egy-két kiegészítés az eddigi tesztekhez.

A manual-tests/ mappában a számozott fileok a tesztek, és a manual-tests/results/ mappában a tesztek végrehajtásának eredményei vannak.

Az új tesztek 07-es sorszámtól felfele vannak, de betettem egy új lépést a 02-es tesztbe is, ami felfed egy eddig ismeretlen hibát.
Az összes tesztet újból végrehajtottam az eredményüket a [Eredmények - 2021.05.16](https://github.com/BME-MIT-IET/iet-hf2021-sumatra-csak-jobb/blob/manual-testing/manual-tests/results/Eredm%C3%A9nyek%20-%202021.05.16.md)-ba írtam.